### PR TITLE
embedded-jmxtrans: Make Tomcat JMX Domain configurable to deploy on CloudBees

### DIFF
--- a/embedded-jmxtrans-webapp-coktail/src/main/cloudbees/cloudbees-config-sample.xml
+++ b/embedded-jmxtrans-webapp-coktail/src/main/cloudbees/cloudbees-config-sample.xml
@@ -31,6 +31,8 @@
  -->
 <config>
     <!-- EMBEDDED JMXTRANS -->
+    <param name="tomcat.jmxDomain" value="localEngine" />
+
     <param name="graphite.host" value="carbon.hostedgraphite.com" />
     <param name="graphite.port" value="2004" />
     <param name="graphite.namePrefix" value="<<YOUR_HOSTED_GRAPHITE_API_KEY>>.servers.cloudbees." />

--- a/embedded-jmxtrans-webapp-coktail/src/main/resources/jmxtrans.json
+++ b/embedded-jmxtrans-webapp-coktail/src/main/resources/jmxtrans.json
@@ -33,7 +33,7 @@
 
         },
         {
-            "objectName": "Catalina:type=Manager,context=/,host=localhost",
+            "objectName": "${tomcat.jmxDomain:Catalina}:type=Manager,context=/,host=localhost",
             "resultAlias": "website",
             "attributes": [
                 {


### PR DESCRIPTION
...dBees (where domain is "localEngine" instead of "Catalina")
