### PR TITLE
Allow default embedded-jmxtrans config overriding for "queryIntervalInSeconds", "numQueryThreads", "numExportThreads", "exportIntervalInSeconds" & "exportBatchSize"

### DIFF
--- a/embedded-jmxtrans-webapp-coktail/src/main/resources/jmxtrans.json
+++ b/embedded-jmxtrans-webapp-coktail/src/main/resources/jmxtrans.json
@@ -102,5 +102,10 @@
             "enabled": "${librato.enabled:false}"
         }
     }
-]
+],
+    "queryIntervalInSeconds": "${jmxtrans.queryIntervalInSeconds:31}",
+    "numQueryThreads": "${jmxtrans.numQueryThreads:7}",
+    "numExportThreads": "${jmxtrans.numExportThreads:3}",
+    "exportIntervalInSeconds": "${jmxtrans.exportIntervalInSeconds:9}",
+    "exportBatchSize": "${jmxtrans.exportBatchSize:51}"
 }


### PR DESCRIPTION
Allow default embedded-jmxtrans config overriding for "queryIntervalInSeconds", "numQueryThreads", "numExportThreads", "exportIntervalInSeconds" & "exportBatchSize"
